### PR TITLE
Upstream openocd configuration updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 #specify the new value of XILINX_TOP in the environment
 export XILINX_TOP=/opt/Xilinx
 export XILINX_VIVADO=$(XILINX_TOP)/Vivado/2018.1
-export TOP=$(PWD)
-export RISCV=$(TOP)/distrib
 export PATH:=$(RISCV)/bin:$(XILINX_VIVADO)/bin:$(XILINX_TOP)/SDK/2018.1/bin:$(XILINX_TOP)/DocNav:$(PATH)
 export REMOTE=192.168.0.51
 export USB=xyzzy
@@ -99,7 +97,7 @@ customise: $(CARDMEM).log
 /proc/sys/fs/binfmt_misc/qemu-riscv64: ./qemu-riscv64
 	sudo update-binfmts --import $<
 
-debug: riscv-openocd/STAMP.openocd ./distrib/bin/openocd /etc/udev/rules.d/52-xilinx-digilent-usb.rules
+debug: $(RISCV)/bin/openocd /etc/udev/rules.d/52-xilinx-digilent-usb.rules
 	openocd -f openocd-nexys4ddr.cfg
 
 /etc/udev/rules.d/52-xilinx-digilent-usb.rules:

--- a/Makefile
+++ b/Makefile
@@ -112,18 +112,18 @@ debug: riscv-openocd/STAMP.openocd ./distrib/bin/openocd /etc/udev/rules.d/52-xi
 	sudo udevadm control --reload
 	sudo udevadm trigger --action=add
 
-EXE = riscv-pk/build/bbl
+EXE = boot.bin
 gdb: $(EXE)
 	riscv64-unknown-elf-gdb -tui $(EXE)
 
-./distrib/bin/openocd:
+./distrib/bin/openocd: riscv-openocd/STAMP.openocd
 	(cd riscv-openocd; find . -iname configure.ac | sed s/configure.ac/m4/ | xargs mkdir -p; autoreconf -i)
 	(mkdir riscv-openocd/build; cd riscv-openocd/build; ../configure --prefix=$(RISCV) --enable-remote-bitbang --enable-jtag_vpi --disable-werror)
-	make -C riscv-openocd/build
-	make -C riscv-openocd/build install
+	make -s -C riscv-openocd/build
+	make -s -C riscv-openocd/build install
 
 riscv-openocd/STAMP.openocd:
-	git clone -b ariane-v0.7 --recursive https://github.com/lowRISC/riscv-openocd.git
+	git clone -b lowrisc-v0.7 --recursive https://github.com/jrrk2/riscv-openocd.git
 	touch $@
 
 boot.bin:

--- a/Makefile
+++ b/Makefile
@@ -112,20 +112,6 @@ debug: riscv-openocd/STAMP.openocd ./distrib/bin/openocd /etc/udev/rules.d/52-xi
 	sudo udevadm control --reload
 	sudo udevadm trigger --action=add
 
-EXE = boot.bin
-gdb: $(EXE)
-	riscv64-unknown-elf-gdb -tui $(EXE)
-
-./distrib/bin/openocd: riscv-openocd/STAMP.openocd
-	(cd riscv-openocd; find . -iname configure.ac | sed s/configure.ac/m4/ | xargs mkdir -p; autoreconf -i)
-	(mkdir riscv-openocd/build; cd riscv-openocd/build; ../configure --prefix=$(RISCV) --enable-remote-bitbang --enable-jtag_vpi --disable-werror)
-	make -s -C riscv-openocd/build
-	make -s -C riscv-openocd/build install
-
-riscv-openocd/STAMP.openocd:
-	git clone -b lowrisc-v0.7 --recursive https://github.com/jrrk2/riscv-openocd.git
-	touch $@
-
 boot.bin:
 	curl -L -O https://github.com/lowRISC/lowrisc-chip/releases/download/v0.7-rc1/$@
 

--- a/openocd-nexys4ddr.cfg
+++ b/openocd-nexys4ddr.cfg
@@ -11,8 +11,9 @@ set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 6 -expected-id 0x13631093
 
 set _TARGETNAME $_CHIPNAME.cpu
-target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos riscv
 
-init
+$_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 10000 -work-area-backup 1
 
+init 
 halt

--- a/openocd-nexys4ddr.cfg
+++ b/openocd-nexys4ddr.cfg
@@ -9,9 +9,11 @@ ftdi_layout_init 0x0088 0x008b
 
 set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 6 -expected-id 0x13631093
-
 set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos riscv
+riscv set_ir idcode 0x09
+riscv set_ir dtmcs 0x22
+riscv set_ir dmi 0x23
 
 $_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 10000 -work-area-backup 1
 


### PR DESCRIPTION
Upstream openocd uses command parameters for chain numbers instead of the refresh-v0.6 approach of hardwiring the IDs. This requires updating the config and allows upstream riscv-openocd to be used.